### PR TITLE
First stab at creating an interface for ONNX semantics

### DIFF
--- a/src/Data/DependentList.agda
+++ b/src/Data/DependentList.agda
@@ -1,0 +1,9 @@
+
+module Data.DependentList where
+
+open import Data.List.Base
+open import Level
+
+data DepList {a b} {A : Set a} (B : A → Set b) : List A → Set (a ⊔ b) where
+  [] : DepList B []
+  _∷_ : ∀ {x xs} → B x → DepList B xs → DepList B (x ∷ xs)

--- a/src/ONNX/Example.agda
+++ b/src/ONNX/Example.agda
@@ -1,0 +1,101 @@
+module ONNX.Example where
+
+open import Data.Bool.Base
+open import Data.Maybe.Base
+open import Data.String.Base
+open import Data.List.Base
+open import Agda.Builtin.Float using (Float)
+open import Level
+
+open import tensor
+
+open import ONNX.Syntax
+open import ONNX.Semantics
+
+----------------------------------------------------------------------------
+-- Syntax
+----------------------------------------------------------------------------
+
+-- Types in the ONNX specification
+data ONNXType : Set where
+  float64        : ONNXType
+  -- float16        : ONNXType
+  -- float32        : ONNXType
+  -- bfloat16       : ONNXType
+  -- float8e4m3fn   : ONNXType
+  -- float8e5m2     : ONNXType
+  -- float8e4m3fnuz : ONNXType
+  -- float8e5m2fnuz : ONNXType
+  -- float4e2m1     : ONNXType
+  -- int8           : ONNXType
+  -- int16          : ONNXType
+  -- int32          : ONNXType
+  -- int64          : ONNXType
+  -- uint8          : ONNXType
+  -- uint16         : ONNXType
+  -- uint32         : ONNXType
+  -- uint64         : ONNXType
+
+-- Equivalence between two ONNX types
+_==_ : ONNXType → ONNXType → Bool
+float64 == float64 = true
+
+ONNXTensor : TensorSignature ONNXType → Set
+ONNXTensor (tensorSig float64 shape) = Tensor Float shape
+
+data ONNXOperator : InputsSignature ONNXType → OutputsSignature ONNXType → Set where
+  constant : ∀ {sig} → ONNXTensor sig → ONNXOperator [] (sig ∷ [])
+  add : ∀ {sig} → ONNXOperator (sig ∷ sig ∷ []) (sig ∷ [])
+
+data ONNXNetwork : NetworkSignature ONNXType → Set where
+  input : ∀ inputSig → ONNXNetwork (networkSig inputSig inputSig)
+
+parseConstant : (τ : ONNXType) → String → Maybe (ONNXTensor (tensorSig τ []))
+parseConstant float64 s = {!!}
+
+exampleSyntax : ONNXSyntax
+exampleSyntax = record
+  { ONNXType = ONNXType
+  ; ONNXBool = {!!}
+  ; ONNXTensor = ONNXTensor
+  ; ONNXNetwork = ONNXNetwork
+  ; parseConstant = parseConstant
+  }
+
+----------------------------------------------------------------------------
+-- Example semantics
+----------------------------------------------------------------------------
+
+⟦_⟧type : ONNXType → Set
+⟦ float64 ⟧type = Float
+
+⟦_⟧tensor : ∀ {sig} → ONNXTensor sig → TensorSemantics ⟦_⟧type sig
+⟦_⟧tensor {tensorSig float64 shape} tensor = tensor
+
+⟦constant⟧ : ∀ {sig} → ONNXTensor sig → {!!}
+⟦constant⟧ = {!!}
+
+⟦add⟧ : ∀ {sig} → ONNXTensor sig → {!!}
+⟦add⟧ = {!!}
+
+⟦_⟧network : ∀ {sig} → ONNXNetwork sig → NetworkSemantics ⟦_⟧type sig
+⟦_⟧network = {!!}
+
+⟦_⟧neg : ∀ (τ : ONNXType) → TensorOp1 ⟦ τ ⟧type ⟦ τ ⟧type
+⟦ float64 ⟧neg = {!!}
+
+⟦_⟧add : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type ⟦ τ ⟧type
+⟦ float64 ⟧add = {!!}
+
+⟦_⟧mul : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type ⟦ τ ⟧type
+⟦ float64 ⟧mul = {!!}
+
+exampleSemantics : ONNXSemantics exampleSyntax
+exampleSemantics = record
+  { ⟦_⟧type    = ⟦_⟧type
+  ; ⟦_⟧tensor  = ⟦_⟧tensor
+  ; ⟦_⟧network = ⟦_⟧network
+  ; ⟦_⟧neg     = ⟦_⟧neg
+  ; ⟦_⟧add     = ⟦_⟧add
+  ; ⟦_⟧mul     = ⟦_⟧mul
+  }

--- a/src/ONNX/Semantics.agda
+++ b/src/ONNX/Semantics.agda
@@ -1,0 +1,55 @@
+
+open import ONNX.Syntax
+
+module ONNX.Semantics where
+
+open import Data.Bool.Base
+open import Data.DependentList
+open import Level
+
+open import tensor
+
+-- The type of unary tensor operations
+TensorOp1 : Set → Set → Set
+TensorOp1 τ₁ τ₂ = ∀ {shape} → Tensor τ₁ shape → Tensor τ₂ shape
+
+-- The type of binary tensor operations
+TensorOp2 : Set → Set → Set → Set
+TensorOp2 τ₁ τ₂ τ₃ = ∀ {shape} → Tensor τ₁ shape → Tensor τ₂ shape → Tensor τ₃ shape
+
+TensorSemantics : ∀ {Types : Set} → (Types → Set) → TensorSignature Types → Set
+TensorSemantics sem (tensorSig τ shape) = Tensor (sem τ) shape
+
+InputsSemantics : ∀ {Types : Set} → (Types → Set) → InputsSignature Types → Set
+InputsSemantics sem tensorSigs = DepList (TensorSemantics sem) tensorSigs
+
+OutputsSemantics : ∀ {Types : Set} → (Types → Set) → InputsSignature Types → Set
+OutputsSemantics sem tensorSigs = DepList (TensorSemantics sem) tensorSigs
+
+-- The semantics of networks
+NetworkSemantics : ∀ {Types : Set} → (Types → Set) → NetworkSignature Types → Set
+NetworkSemantics sem (networkSig inputs outputs) =
+  InputsSemantics sem inputs → OutputsSemantics sem outputs
+
+-- An implementation of the subset of the semantics of ONNX necessary to define
+-- the semantics of VNN-LIB.
+record ONNXSemantics (syn : ONNXSyntax) : Set₁ where
+  open ONNXSyntax syn
+  field
+    -- The interpretation of ONNX types
+    ⟦_⟧type    : ONNXType → Set
+    -- The interpretation of ONNX tensors
+    ⟦_⟧tensor  : ∀ {sig} → ONNXTensor sig → TensorSemantics ⟦_⟧type sig
+    -- The interpretation of ONNX networks
+    ⟦_⟧network : ∀ {sig} → ONNXNetwork sig → NetworkSemantics ⟦_⟧type sig
+    
+    -- The interpretation of the basic ONNX tensor operations at each type
+    ⟦_⟧≤   : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type Bool
+    ⟦_⟧<   : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type Bool
+    ⟦_⟧≥   : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type Bool
+    ⟦_⟧>   : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type Bool
+    ⟦_⟧=   : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type Bool
+    ⟦_⟧≠   : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type Bool
+    ⟦_⟧neg : ∀ (τ : ONNXType) → TensorOp1 ⟦ τ ⟧type ⟦ τ ⟧type
+    ⟦_⟧add : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type ⟦ τ ⟧type
+    ⟦_⟧mul : ∀ (τ : ONNXType) → TensorOp2 ⟦ τ ⟧type ⟦ τ ⟧type ⟦ τ ⟧type

--- a/src/ONNX/Syntax.agda
+++ b/src/ONNX/Syntax.agda
@@ -1,0 +1,47 @@
+module ONNX.Syntax where
+
+open import Data.Bool.Base
+open import Data.List.Base
+open import Data.String.Base
+open import Data.Maybe.Base
+open import Level
+open import tensor using (TensorShape)
+
+-- A signature for a tensor
+record TensorSignature (Types : Set) : Set where
+  constructor tensorSig
+  field
+    tensorType : Types
+    tensorDims : TensorShape
+
+InputsSignature : (Types : Set) → Set
+InputsSignature Types = List (TensorSignature Types)
+
+OutputsSignature : (Types : Set) → Set
+OutputsSignature Types = List (TensorSignature Types)
+
+-- A signature for a network
+record NetworkSignature (Types : Set) : Set where
+  constructor networkSig
+  field
+    inputs : InputsSignature Types
+    outputs : OutputsSignature Types
+
+-- An implementation of the subset of syntax of ONNX neccessary to define
+-- the syntax of VNN-LIB.
+record ONNXSyntax : Set₁ where
+  field
+    -- The set of types in the ONNX specification
+    ONNXType : Set
+
+    -- We must have the boolean type
+    ONNXBool : ONNXType
+
+    -- The internal ONNX representation of tensors
+    ONNXTensor : TensorSignature ONNXType → Set
+
+    -- The internal ONNX representation of networks
+    ONNXNetwork : NetworkSignature ONNXType → Set
+
+    -- A method of parsing strings into zero-dimensaional ONNX tensors (i.e. a constant)
+    parseConstant : (τ : ONNXType) → String → Maybe (ONNXTensor (tensorSig τ []))

--- a/src/VNNLIB/Example.agda
+++ b/src/VNNLIB/Example.agda
@@ -1,6 +1,6 @@
 module vnnlib-semantics-demo where
 
-open import Data.String using (String; fromList)
+open import Data.String.Base using (String; fromList)
 open import Data.Nat
 open import Data.Bool
 open import Data.Product using (_,_)


### PR DESCRIPTION
This is the first step in parameterising the whole VNNLIB semantics by an abstract copy of the ONNX semantics. 

Here I have defined an interface to ONNX semantics. Next step is to get the VNNLIB semantics to use this instead. @developing-ar we should discuss once you have finished your exams!