### PR TITLE
Make network context non-empty

### DIFF
--- a/src/VNNLIB/Parser.agda
+++ b/src/VNNLIB/Parser.agda
@@ -8,7 +8,7 @@ module VNNLIB.Parser
 
 open import Data.List as List using (List; []; _∷_)
 open import Data.List.Properties using (length-map)
-open import Data.List.NonEmpty as List⁺
+open import Data.List.NonEmpty as List⁺ hiding (_∷⁺_)
 open import Data.Bool as Bool
 open import Data.String as String using (String; _==_)
 open import Relation.Binary.PropositionalEquality
@@ -271,12 +271,13 @@ checkNetworkDeclaration Γ (B.networkDef varName equivs inputs hidden outputs) =
   checkNamesLocallyUnique decl
   return decl
 
-checkNetworks : List B.NetworkDefinition → TCM NetworkContext
-checkNetworks [] = return []
+checkNetworks : List B.NetworkDefinition → TCM NetworkContext⁺
+checkNetworks [] = throw "Must be at least one Network Declaration"
 checkNetworks (n ∷ ns) = do
   ns' ← checkNetworks ns
-  n' ← checkNetworkDeclaration ns' n
-  return (ns' ∷ n')
+  let ns'' = toNetworkContext ns'
+  n' ← checkNetworkDeclaration ns'' n
+  return (ns'' ∷⁺ n')
 
 ----------------
 -- Assertions --
@@ -376,7 +377,7 @@ module _ (Γ : NetworkContext) where
 checkQuery : B.Query → TCM Query
 checkQuery (B.vNNLibQuery ver networks assertions) = do
   networks' ← checkNetworks networks
-  assertions' ← checkAssertions networks' assertions
+  assertions' ← checkAssertions (toNetworkContext networks') assertions
   return (query networks' assertions')
 
 parseQuery : String → String ⊎ Query

--- a/src/VNNLIB/Semantics.agda
+++ b/src/VNNLIB/Semantics.agda
@@ -165,10 +165,10 @@ module _ (Δ : Environment Γ) where
 -------------
 
 QuerySemantics : Set₁
-QuerySemantics = (q : Query) → NetworkImplementations (context q) → Set
+QuerySemantics = (q : Query) → NetworkImplementations (toNetworkContext (context q)) → Set
 
 ⟦query⟧ : QuerySemantics
 ⟦query⟧ (query Γ assertions) networks =
-  ∃ λ (assignment : InputAssignments Γ) →
+  ∃ λ (assignment : InputAssignments (toNetworkContext Γ)) →
     let Δ = createEnvironment networks assignment in
     True (⟦assertionList⟧ Δ assertions)

--- a/src/VNNLIB/Solver.agda
+++ b/src/VNNLIB/Solver.agda
@@ -17,7 +17,7 @@ open import VNNLIB.Semantics onnxSemantics
 Solver : Set
 Solver =
   (q : Query) →
-  (N : NetworkImplementations (context q)) →
+  (N : NetworkImplementations (toNetworkContext(context q))) →
   Dec (⟦query⟧ q N)
 
 -- A solver is an incomplete decision procedure that decides the
@@ -25,5 +25,5 @@ Solver =
 IncompleteSolver : Set
 IncompleteSolver =
   (q : Query) →
-  (N : NetworkImplementations (context q)) →
+  (N : NetworkImplementations (toNetworkContext(context q))) →
   Maybe (⟦query⟧ q N)

--- a/src/VNNLIB/Syntax.agda
+++ b/src/VNNLIB/Syntax.agda
@@ -85,12 +85,12 @@ mutual
 
   ----------------------
   -- Network contexts --
-  ----------------------
+  ---------------------- 
 
   data NetworkContext : Set where
     [] : NetworkContext
     _∷_ : (Γ : NetworkContext) → NetworkDeclaration Γ → NetworkContext
-
+  
   ------------------------
   -- Network definition --
   ------------------------
@@ -138,7 +138,7 @@ mutual
   data NetworkEquivalence (Γ : NetworkContext) (type : NetworkType ElementType) : Set where
     equal-to      : EqualNetworkVariable Γ type → NetworkEquivalence Γ type
     isomorphic-to : IsomorphicNetworkVariable Γ type → NetworkEquivalence Γ type
-  
+
   ---------------------------------------
   -- Restrictions on network variables --
   ---------------------------------------
@@ -287,6 +287,16 @@ module _ (Γ : NetworkContext) where
   data Assertion : Set where
     assert : BoolExpr → Assertion
 
+------------------------------------------
+-- Network Context non-empty constraint --
+------------------------------------------
+
+data NetworkContext⁺ : Set where
+  _∷⁺_ : (Γ : NetworkContext) → (d : NetworkDeclaration Γ) → NetworkContext⁺ 
+
+toNetworkContext : NetworkContext⁺  → NetworkContext
+toNetworkContext (Γ ∷⁺ d) = Γ ∷ d
+
 -------------
 -- Queries --
 -------------
@@ -294,8 +304,8 @@ module _ (Γ : NetworkContext) where
 record Query : Set where
   constructor query
   field
-    context : NetworkContext
-    assertions : List (Assertion context)
+    context : NetworkContext⁺
+    assertions : List (Assertion (toNetworkContext context))
 
 open Query public
 

--- a/src/VNNLIB/Theories/HiddenNodes.agda
+++ b/src/VNNLIB/Theories/HiddenNodes.agda
@@ -28,7 +28,7 @@ NoHiddenNodes network = length (hiddenDeclarations network) ≡ 0
 
 -- A query lives in the NH theory 
 NoHiddenNodesTheory : Theory
-NoHiddenNodesTheory (query networks _) = AllNetworks NoHiddenNodes networks
+NoHiddenNodesTheory (query networks _) = AllNetworks NoHiddenNodes (toNetworkContext networks)
 
 
 -------

--- a/src/VNNLIB/Theories/MultipleInputsOutputs.agda
+++ b/src/VNNLIB/Theories/MultipleInputsOutputs.agda
@@ -33,7 +33,7 @@ SingleInputOutput network =
 -- A query lives in the SIO theory 
 SingleInputsOutputsTheory : Theory
 SingleInputsOutputsTheory (query networks _) =
-  AllNetworks SingleInputOutput networks
+  AllNetworks SingleInputOutput (toNetworkContext networks)
 
 ---------
 -- MIO --

--- a/src/VNNLIB/Theories/MultipleNetworks.agda
+++ b/src/VNNLIB/Theories/MultipleNetworks.agda
@@ -21,7 +21,7 @@ open import VNNLIB.Theories.Definition networkSyntax
 
 
 NetworksPredicate : Set₁
-NetworksPredicate = Pred NetworkContext 0ℓ
+NetworksPredicate = Pred NetworkContext⁺ 0ℓ
 
 ----------------
 -- Theory set --
@@ -38,13 +38,12 @@ data MultipleNetworks : Set where
 ----------  
 
 SingleNetwork : NetworksPredicate
-SingleNetwork networks = networkContextLength networks ≡ 1
+SingleNetwork networks = networkContextLength (toNetworkContext networks) ≡ 1
   where
     networkContextLength : NetworkContext → ℕ
     networkContextLength [] = ℕ.zero
     networkContextLength (Γ ∷ x) = ℕ.suc (networkContextLength Γ)
-
-
+    
 -- A query that lives in the SNET theory
 SingleNetworkTheory : Theory
 SingleNetworkTheory (query networks _) = SingleNetwork networks
@@ -55,8 +54,7 @@ SingleNetworkTheory (query networks _) = SingleNetwork networks
 
 -- A query where all networks are equal
 MultipleEqualNetworks : NetworksPredicate
-MultipleEqualNetworks [] = ⊥ -- TODO: sort out empty context
-MultipleEqualNetworks (networks ∷ x) = NonEquivalentNetwork x × AllNetworks EqualNetwork networks
+MultipleEqualNetworks (networks ∷⁺ x) = NonEquivalentNetwork x × AllNetworks EqualNetwork networks
 
 -- A query that lives in the MENET theory
 MultipleEqualNetworksTheory : Theory
@@ -68,8 +66,7 @@ MultipleEqualNetworksTheory (query networks _) = MultipleEqualNetworks networks
 
 -- A network that is equal to another network is also in the isomorphic theory
 MultipleIsomorphicNetworks : NetworksPredicate
-MultipleIsomorphicNetworks [] = ⊥ -- TODO: sort out empty context
-MultipleIsomorphicNetworks (networks ∷ x) = NonEquivalentNetwork x × AllNetworks TheoryIsomorphicNetwork networks
+MultipleIsomorphicNetworks (networks ∷⁺ x) = NonEquivalentNetwork x × AllNetworks TheoryIsomorphicNetwork networks
   where
     TheoryIsomorphicNetwork : NetworkPredicate
     TheoryIsomorphicNetwork network = IsomorphicNetwork network ⊎ EqualNetwork network


### PR DESCRIPTION
Introduced `NetworkContext⁺` construct that wraps `NetworkContext` for the most non-intrusive implementation of the non-empty contraint at the `Query` level. This was suggested in this [reply](https://github.com/VNNLIB/VNNLIB-Agda/pull/23#discussion_r2654515528).

Considerations:

1. `NetworkDeclaration` needs to be parameterized by a possibly empty `NetworkContext`.
2. Using `[_]` with `NetworkDeclaration` instead of `[]` constructor is not possible as the empty context base case is required (as per 1). Suggested [here](https://github.com/VNNLIB/VNNLIB-Agda/pull/23#discussion_r2659266824).
3. Using the `NonEmpty.List` approach wraps back and targets `NetworkDeclaration` which should not be possible (as per 1). Suggested [here](https://github.com/VNNLIB/VNNLIB-Agda/pull/23#discussion_r2656399417).